### PR TITLE
Only enqueue JavaScript on root blog if BuddyPress is not in multiblog mode

### DIFF
--- a/bp-follow-core.php
+++ b/bp-follow-core.php
@@ -319,6 +319,12 @@ class BP_Follow_Component extends BP_Component {
 		if ( ! is_user_logged_in() )
 			return;
 
+		// Do not add the script on network sites if not on multiblog mode
+		// just add follow script on the root blog 
+		if( !bp_is_multiblog_mode() && !bp_is_root_blog() )
+			return;
+
+
 		wp_enqueue_script( 'bp-follow-js', constant( 'BP_FOLLOW_URL' ) . '_inc/bp-follow.js', array( 'jquery' ) );
 	}
 


### PR DESCRIPTION
This plugin was adding the bp-follow.js script on all sites on our network when BuddyPress was network enabled.  This corrects the plugin so that only adds the script on the main BuddyPress root site where things like the activity feed and profiles reside. 
