### PR TITLE
return template path on activity screen

### DIFF
--- a/_inc/bp-follow-blogs.php
+++ b/_inc/bp-follow-blogs.php
@@ -236,9 +236,9 @@ class BP_Follow_Blogs {
 	 *
 	 * @todo Maybe add this in BP Core?
 	 */
-	function set_activity_scope_on_activity_directory() {
+	function set_activity_scope_on_activity_directory( $template ) {
 		if ( empty( $_GET['scope'] ) ) {
-			return;
+			return $template;
 		}
 
 		$scope = wp_filter_kses( $_GET['scope'] );
@@ -251,6 +251,8 @@ class BP_Follow_Blogs {
 
 		//reset the dropdown menu to 'Everything'
 		@setcookie( 'bp-activity-filter', '-1',   0, '/' );
+		
+		return $template;
 	}
 
 	/**


### PR DESCRIPTION
Am absolutely loving the new blog-following feature. I'll detail what I've had to do to adapt it to the needs of the bp-working-papers plugin at another time. Just thought you'd like to have this fix PRed as currently the activity stream page loses the reference to its template.
