### PR TITLE
init Follow Blogs immediately

### DIFF
--- a/_inc/bp-follow-blogs.php
+++ b/_inc/bp-follow-blogs.php
@@ -1,18 +1,6 @@
 <?php
 
 /**
- * Follow Blogs Loader.
- *
- * @since 1.3.0
- */
-function bp_follow_blogs_init() {
-	global $bp;
-
-	$bp->follow->blogs = new BP_Follow_Blogs;
-}
-add_action( 'bp_loaded', 'bp_follow_blogs_init', 20 );
-
-/**
  * Follow Blogs module.
  *
  * @since 1.3.0
@@ -874,3 +862,16 @@ class BP_Follow_Blogs_Screens {
 	}
 
 }
+
+/**
+ * Follow Blogs Loader.
+ *
+ * @since 1.3.0
+ */
+function bp_follow_blogs_init() {
+	global $bp;
+
+	$bp->follow->blogs = new BP_Follow_Blogs;
+}
+
+bp_follow_blogs_init();


### PR DESCRIPTION
Since the 'bp-follow-blogs.php' file is included during the `bp_loaded` action, there's no need to hook `bp_follow_blogs_init()` to `bp_loaded`. Indeed, doing so produces anomalies in the `bp_loaded` callback array such that the priority order is messed up. See https://core.trac.wordpress.org/ticket/27428

It'd be nice if there were a `do_action( 'bp_follow_blogs_loaded' )` following the init so an extension of an extension of an extension of an extension can be notified :-)
