### PR TITLE
parse query string regardless of type

### DIFF
--- a/_inc/bp-follow-blogs.php
+++ b/_inc/bp-follow-blogs.php
@@ -281,7 +281,7 @@ class BP_Follow_Blogs {
 		}
 
 		// parse querystring into an array
-		wp_parse_str( $qs, $r );
+		$r = wp_parse_args( $qs );
 
 		// set scope if a user is on a user's "Followed Sites" page
 		if ( bp_is_user_blogs() && bp_is_current_action( constant( 'BP_FOLLOW_BLOGS_USER_FOLLOWING_SLUG' ) ) ) {
@@ -335,7 +335,7 @@ class BP_Follow_Blogs {
 		}
 
 		// parse querystring into an array
-		wp_parse_str( $qs, $r );
+		$r = wp_parse_args( $qs );
 
 		if ( bp_is_current_action( constant( 'BP_FOLLOW_BLOGS_USER_ACTIVITY_SLUG' ) ) ) {
 			$r['scope'] = 'followblogs';


### PR DESCRIPTION
I've found that the incoming query string is not always, ahem, a string. Some plugins pass an array. Using `wp_parse_args()` seems functionally identical and avoids a PHP warning when that's the case. Feel free to ignore if this plugin shouldn't accommodate query strings that are not strings.
