### PR TITLE
Delete follow relationships for a deleted blog

### DIFF
--- a/_inc/bp-follow-classes.php
+++ b/_inc/bp-follow-classes.php
@@ -347,4 +347,17 @@ class BP_Follow {
 
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$bp->follow->table_name} WHERE leader_id = %d OR follower_id = %d AND follow_type = ''", $user_id, $user_id ) );
 	}
+
+	/**
+	 * Deletes all follow relationships for a given blog.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param int $blog_id The blog ID
+	 */
+	public static function delete_all_for_blog( $blog_id = 0 ) {
+		global $bp, $wpdb;
+
+		$wpdb->query( $wpdb->prepare( "DELETE FROM {$bp->follow->table_name} WHERE leader_id = %d AND follow_type = 'blogs'", $blog_id ) );
+	}
 }

--- a/_inc/bp-follow-functions.php
+++ b/_inc/bp-follow-functions.php
@@ -213,6 +213,24 @@ add_action( 'delete_user',	'bp_follow_remove_data' );
 add_action( 'make_spam_user',	'bp_follow_remove_data' );
 
 /**
+ * Removes follow relationships for all users from a blog which is deleted or spammed
+ *
+ * @since 1.3.0
+ *
+ * @uses BP_Follow::delete_all_for_user() Deletes user ID from all following / follower records
+ *
+ * @param int $blog_id The numeric ID of the blog
+ */
+function bp_follow_blog_deleted( $blog_id, $drop = false ) {
+	do_action( 'bp_follow_before_blog_deleted', $blog_id );
+
+	BP_Follow::delete_all_for_blog( $blog_id );
+
+	do_action( 'bp_follow_blog_deleted', $blog_id );
+}
+add_action( 'delete_blog', 'bp_follow_blog_deleted', 10, 1 );
+
+/**
  * Is an AJAX request currently taking place?
  *
  * Since BP Follow still supports BP 1.5, we can't simply use the DOING_AJAX


### PR DESCRIPTION
@r-a-y When a blog is deleted, BuddyPress Follow does not delete the entries in the `wp_bp_follow` table that refer to that blog. This PR fixes this.
